### PR TITLE
Build PHP Jobs to Interface with the Food2Fork API

### DIFF
--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Endpoints for handling data pulls from the Food2Fork API.
+ *
+ * @author John J Lincoln <jlincoln88@gmail.com>
+ * @copyright 2018 Arctic Pangolin
+ */
+
 namespace App\Http\Controllers\API;
 
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -82,7 +82,7 @@ class apiController extends Controller
 
         // Configure cURL
         $params = [
-            'key'  => env('F2F_API_KEY'),
+            'key' => env('F2F_API_KEY'),
             'rId' => $recipe->api_f2f_id
         ];
         $defaults = [

--- a/app/Jobs/apiGetNewRecipeData.php
+++ b/app/Jobs/apiGetNewRecipeData.php
@@ -1,3 +1,32 @@
 <?php
+/**
+* PHP Script to handle getting recipe specific data from the Food2Fork API.
+*
+* @author John J Lincoln <jlincoln88@gmail.com>
+* @copyright 2018 Arctic Pangolin
+*/
 
-// Get recipe data (ingredients, instructions, etc) from F2F API.
+$params = [
+    'url' => !empty($argv[1]) ? $argv[1] : 'localhost/api/get/recipeData'
+];
+
+// Configure cURL
+$defaults = [
+    CURLOPT_URL => $params['url']
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+curl_exec($ch);
+
+// Check for errors and display the error message
+// TODO: logger? console print? pass up to cron? Not this though
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    echo "cURL error ({$errno}):\n {$error_message}";
+}
+
+// Close the handle and die.
+curl_close($ch);
+die();

--- a/app/Jobs/apiGetNewRecipes.php
+++ b/app/Jobs/apiGetNewRecipes.php
@@ -1,3 +1,32 @@
 <?php
+/**
+* PHP Script to handle getting new recipes from the Food2Fork API.
+*
+* @author John J Lincoln <jlincoln88@gmail.com>
+* @copyright 2018 Arctic Pangolin
+*/
 
-// Get recipes from F2F API.
+$params = [
+    'url' => !empty($argv[1]) ? $argv[1] : 'localhost/api/get/newRecipes'
+];
+
+// Configure cURL
+$defaults = [
+    CURLOPT_URL => $params['url']
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+curl_exec($ch);
+
+// Check for errors and display the error message
+// TODO: logger? console print? pass up to cron? Not this though
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    echo "cURL error ({$errno}):\n {$error_message}";
+}
+
+// Close the handle and die.
+curl_close($ch);
+die();

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Model for Recipes pulled from the Food2Fork API
+ *
+ * @author John J Lincoln <jlincoln88@gmail.com>
+ * @copyright 2018 Arctic Pangolin
+ */
+
 namespace App\Models\API;
 
 use Illuminate\Database\Eloquent\Model;

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -48,6 +48,17 @@ class apiRecipe extends Model
     ];
 
     /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'created_at',
+        'updated_at'
+    ];
+
+    /**
     * Get the apiRecipe that owns the data.
     */
     public function apiRecipeData()

--- a/app/Models/API/apiRecipeData.php
+++ b/app/Models/API/apiRecipeData.php
@@ -41,6 +41,17 @@ class apiRecipeData extends Model
     ];
 
     /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'created_at',
+        'updated_at'
+    ];
+
+    /**
     * Get the apiRecipeData that owns the data.
     */
     public function apiRecipe()

--- a/app/Models/API/apiRecipeData.php
+++ b/app/Models/API/apiRecipeData.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Model for Recipe Data pulled from the Food2Fork API
+ *
+ * @author John J Lincoln <jlincoln88@gmail.com>
+ * @copyright 2018 Arctic Pangolin
+ */
+
 namespace App\Models\API;
 
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
This PR contains some patches to the api* models, specifically adding $guarded attributes, as well as two php Jobs to send requests to the Food2Fork API. These jobs will invoke our own apiController, which will complete the request.

These Jobs will be invoked via cron jobs.