### PR TITLE
Add Validation Logic to api* Models and Implement Validator in apiController

### DIFF
--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\API\apiRecipe;
 use App\Models\API\apiRecipeData;
+use Validator;
 
 class apiController extends Controller
 {
@@ -60,19 +61,29 @@ class apiController extends Controller
         // Save new models
         // TODO: handle failure
         foreach ($response->recipes as $recipe) {
-            $new_api_recipe = apiRecipe::create([
+            $new_api_recipe = [
                 'api_f2f_id'               => $recipe->recipe_id,
                 'api_recipe_title'         => $recipe->title,
-                'api_recipe_image_url'     => strlen($recipe->image_url) > 191 ? 'too long' : $recipe->image_url,
-                'api_recipe_source_url'    => strlen($recipe->source_url) > 191 ? 'too long' : $recipe->source_url,
-                'api_recipe_f2f_url'       => strlen($recipe->f2f_url) > 191 ? 'too long' : $recipe->f2f_url,
+                'api_recipe_image_url'     => $recipe->image_url,
+                'api_recipe_source_url'    => $recipe->source_url,
+                'api_recipe_f2f_url'       => $recipe->f2f_url,
                 'api_recipe_publisher'     => $recipe->publisher,
-                'api_recipe_publisher_url' => strlen($recipe->publisher_url) > 191 ? 'too long' : $recipe->publisher_url,
+                'api_recipe_publisher_url' => $recipe->publisher_url,
                 'api_recipe_social_rank'   => $recipe->social_rank,
                 'api_recipe_page'          => (int)$api_page
-            ]);
+            ];
+            $validator = Validator::make($new_api_recipe, apiRecipe::$rules);
+            if ($validator->fails()) {
+                //TODO: response
+                print_r($validator->errors());
+                return 'die';
+            }
+            $api_recipe_model =  new apiRecipe();
+            $api_recipe_model->fill($new_api_recipe);
+            $success = $api_recipe_model->save();
         }
-        // TODO: return response!
+        return '$success';
+        // TODO: return response! use the success stuff
     }
 
     /**
@@ -131,5 +142,13 @@ class apiController extends Controller
 
         // TODO: logger? handle failures? return response!
         echo $success ? "Recipe " . $recipe->api_f2f_id . " pulled!" : "Pull failed on recipe " . $recipe->api_f2f_id . "failed...";
+    }
+
+    public function test()
+    {
+        $thing = new apiRecipe();
+        echo $thing->attributes;
+        // echo 'This test was ' . $test;
+        // echo true;
     }
 }

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -17,7 +17,11 @@ use Validator;
 
 class apiController extends Controller
 {
-
+    /**
+     * TODO: Response Object
+     * TODO: Save just the ID of recipes that fail validation
+     * TODO: Logs?
+     */
     /**
      * Retrieves a page of recipes from the F2F API, loads them into apiRecipe
      * models, and saves those models.
@@ -128,11 +132,20 @@ class apiController extends Controller
 
         // Save new models
         foreach ($response->recipe->ingredients as $ingredient) {
-            $new_api_recipe_data = apiRecipeData::create([
+            $new_api_recipe_data = [
                 'api_id'              => $recipe->id,
                 'api_f2f_id'          => $recipe->api_f2f_id,
-                'api_ingredient_data' => (isset($ingredient) && strlen($ingredient) < 191) ? $ingredient : 'not found'
-            ]);
+                'api_ingredient_data' => isset($ingredient) ? $ingredient : 'not found'
+            ];
+            $validator = Validator::make($new_api_recipe_data, apiRecipeData::$rules);
+            if ($validator->fails()) {
+                //TODO: response
+                print_r($validator->errors());
+                return 'die';
+            }
+            $api_recipe_data_model = new apiRecipeData();
+            $api_recipe_data_model->fill($new_api_recipe_data);
+            $success = $api_recipe_data_model->save();
         }
         // TODO: logger? do this whole thing as 1 transaction? handle failures?
 
@@ -142,13 +155,5 @@ class apiController extends Controller
 
         // TODO: logger? handle failures? return response!
         echo $success ? "Recipe " . $recipe->api_f2f_id . " pulled!" : "Pull failed on recipe " . $recipe->api_f2f_id . "failed...";
-    }
-
-    public function test()
-    {
-        $thing = new apiRecipe();
-        echo $thing->attributes;
-        // echo 'This test was ' . $test;
-        // echo true;
     }
 }

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -120,7 +120,7 @@ class apiController extends Controller
             $new_api_recipe_data = apiRecipeData::create([
                 'api_id'              => $recipe->id,
                 'api_f2f_id'          => $recipe->api_f2f_id,
-                'api_ingredient_data' => isset($ingredient) ? $ingredient : 'not found'
+                'api_ingredient_data' => (isset($ingredient) && strlen($ingredient) < 191) ? $ingredient : 'not found'
             ]);
         }
         // TODO: logger? do this whole thing as 1 transaction? handle failures?

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -34,8 +34,9 @@ class apiRecipe extends Model
     */
     public $timestamps = true;
 
+
     /**
-    * The attributes that are mass assignable.
+    * The model attributes that are mass assignable.
     *
     * @var array
     */
@@ -66,6 +67,24 @@ class apiRecipe extends Model
     ];
 
     /**
+    * Validation rules for the model attributes.
+    *
+    * @var array
+    */
+    public static $rules = [
+        'api_recipe_title'         => 'alpha_num|max:191',
+        'api_f2f_id'               => 'max:10',
+        'api_recipe_title'         => 'max:191',
+        'api_recipe_image_url'     => 'max:191',
+        'api_recipe_source_url'    => 'max:191',
+        'api_recipe_f2f_url'       => 'max:191',
+        'api_recipe_publisher'     => 'max:191',
+        'api_recipe_publisher_url' => 'max:191',
+        'api_recipe_social_rank'   => 'numeric',
+        'api_recipe_page'          => 'numeric'
+    ];
+
+    /**
     * Get the apiRecipe that owns the data.
     */
     public function apiRecipeData()
@@ -74,7 +93,7 @@ class apiRecipe extends Model
     }
 
     /**
-    * Scope a query to only include recipes that have not had their data pulled.
+    * Scopes a query to only include recipes that have not had their data pulled.
     *
     * @param \Illuminate\Database\Eloquent\Builder $query
     * @return \Illuminate\Database\Eloquent\Builder
@@ -82,58 +101,5 @@ class apiRecipe extends Model
     public function scopeDataNotPulled($query)
     {
         return $query->where('api_recipe_data_pulled', false);
-    }
-
-    /**
-     * VALIDATION
-     */
-
-    /**
-     * [protected description]
-     * @var [type]
-     */
-    protected $rules = [
-        'api_recipe_title' => 'alpha_num|max:191',
-        'api_f2f_id' =? 'max:10',
-        'api_recipe_title' => 'max:191',
-        'api_recipe_image_url' => 'max:191',
-        'api_recipe_source_url' => 'max:191',
-        'api_recipe_f2f_url' => 'max:191',
-        'api_recipe_publisher' => 'max:191',
-        'api_recipe_publisher_url' => 'max:191',
-        'api_recipe_social_rank' => 'alpha_num',
-        'api_recipe_page' => 'numeric'
-    ];
-
-    /**
-     * [protected description]
-     * @var [type]
-     */
-    protected $errors;
-
-    /**
-     * [validate description]
-     * @param  [type] $data [description]
-     * @return [type]       [description]
-     */
-    public function validate($data)
-    {
-        $v = Validator::make($data, $this->rules);
-
-        if ($v->fails()) {
-            $this->errors = $v->errors;
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * [errors description]
-     * @return [type] [description]
-     */
-    public function errors()
-    {
-        return $this->errors;
     }
 }

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -83,4 +83,57 @@ class apiRecipe extends Model
     {
         return $query->where('api_recipe_data_pulled', false);
     }
+
+    /**
+     * VALIDATION
+     */
+
+    /**
+     * [protected description]
+     * @var [type]
+     */
+    protected $rules = [
+        'api_recipe_title' => 'alpha_num|max:191',
+        'api_f2f_id' =? 'max:10',
+        'api_recipe_title' => 'max:191',
+        'api_recipe_image_url' => 'max:191',
+        'api_recipe_source_url' => 'max:191',
+        'api_recipe_f2f_url' => 'max:191',
+        'api_recipe_publisher' => 'max:191',
+        'api_recipe_publisher_url' => 'max:191',
+        'api_recipe_social_rank' => 'alpha_num',
+        'api_recipe_page' => 'numeric'
+    ];
+
+    /**
+     * [protected description]
+     * @var [type]
+     */
+    protected $errors;
+
+    /**
+     * [validate description]
+     * @param  [type] $data [description]
+     * @return [type]       [description]
+     */
+    public function validate($data)
+    {
+        $v = Validator::make($data, $this->rules);
+
+        if ($v->fails()) {
+            $this->errors = $v->errors;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * [errors description]
+     * @return [type] [description]
+     */
+    public function errors()
+    {
+        return $this->errors;
+    }
 }

--- a/app/Models/API/apiRecipeData.php
+++ b/app/Models/API/apiRecipeData.php
@@ -59,6 +59,16 @@ class apiRecipeData extends Model
     ];
 
     /**
+    * Validation rules for the model attributes.
+    *
+    * @var array
+    */
+    public static $rules = [
+        'api_f2f_id'          => 'max:10',
+        'api_ingredient_data' => 'max:191'
+    ];
+
+    /**
     * Get the apiRecipeData that owns the data.
     */
     public function apiRecipe()

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 // Route::middleware('auth:api')->get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/recipeData', 'API\apiController@getRecipeData');
+
+Route::get('/get/test', 'API\apiController@test');

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,5 +21,3 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 // Route::middleware('auth:api')->get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/recipeData', 'API\apiController@getRecipeData');
-
-Route::get('/get/test', 'API\apiController@test');


### PR DESCRIPTION
This PR addresses a bug causing DB insert failures to occur because of un-cleansed input. Validation logic lives within the models, and is passed into a Validator in the concerned controller.

Both Jobs are now completing without any failures.

TODO: Look into implementing a BaseModel which provides validation functionality for the data integrity of the model itself, rather than of the data being used to hydrate it.