### PR TITLE
Improvements to the Endpoints

### DIFF
--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -202,4 +202,25 @@ class apiController extends Controller
             'string'  => $success ? 'Recipe ' . $recipe->api_f2f_id . ' pulled!' : 'Pull failed on recipe ' . $recipe->api_f2f_id
             ]);
     }
+
+    public function getPageInfo()
+    {
+        $recipe = apiRecipe::orderBy('api_recipe_page', 'desc')->first();
+        $current_page = isset($recipe) ? $recipe->api_recipe_page : 1;
+        $next_page = isset($recipe) ? $recipe->api_recipe_page + 1 : 1;
+
+        return response()->json([
+            'current_page' => $current_page,
+            'next_page'    => $next_page
+        ]);
+    }
+
+    public function getUnpulledApiRecipeId()
+    {
+        $recipe = apiRecipe::dataNotPulled()->first();
+
+        return response()->json([
+            'api_f2f_id' => $recipe->api_f2f_id
+        ]);
+    }
 }

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * TODO: doc comment
+ * Controller for handling raw API payloads retrieved from Food2Fork.
  *
  * @author John J Lincoln <jlincoln88@gmail.com>
  * @copyright 2018 Arctic Pangolin
@@ -36,9 +36,14 @@ class apiController extends Controller
         ]);
     }
 
+    /**
+     * Gets the apiRecipe ID and corresponding Food2Fork ID for an apiRecipe that has not been loaded.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function getUnpulledApiRecipeId()
     {
-        $recipe = apiRecipe::dataNotPulled()->noErrors()->first();
+        $recipe = apiRecipe::dataNotLoaded()->noErrors()->first();
 
         return response()->json([
             'api_f2f_id' => $recipe->api_f2f_id,
@@ -46,6 +51,12 @@ class apiController extends Controller
         ]);
     }
 
+    /**
+     * Adds a new apiRecipe model for every recipe in the request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
     public function postApiRecipes(Request $request)
     {
         foreach ($request->new_recipes as $recipe) {
@@ -100,7 +111,8 @@ class apiController extends Controller
     }
 
     /**
-     * [postApiRecipeData description]
+     * Adds new apiRecipeData models for an apiRecipe.
+     *
      * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
@@ -144,7 +156,6 @@ class apiController extends Controller
                 ]);
             }
         }
-        // Mark the apiRecipe as having its data pulled
         $recipe->markRecipeDataLoaded();
         $success = $recipe->save();
         Log::info('Recipe loaded.', [

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -58,19 +58,19 @@ class apiController extends Controller
                 'api_recipe_publisher'     => $recipe['publisher'],
                 'api_recipe_publisher_url' => $recipe['publisher_url'],
                 'api_recipe_social_rank'   => $recipe['social_rank'],
-                'api_recipe_page'          => $request->page
+                'api_recipe_page'          => (int)$request->page
             ];
             $validator = Validator::make($new_api_recipe, apiRecipe::$rules);
             if ($validator->fails()) {
                 Log::error('Load new recipes failed. Recipe failed validation.', [
                     'rId'         => $recipe['recipe_id'],
-                    'page_failed' => $request->page,
+                    'page_failed' => (int)$request->page,
                     'errors'      => $validator->errors()
                 ]);
                 return response()->json([
                     'rId'         => $recipe['recipe_id'],
                     'success'     => 'false',
-                    'page_failed' => $request->page,
+                    'page_failed' => (int)$request->page,
                     'errors'      => $validator->errors()
                 ]);
             }
@@ -90,12 +90,12 @@ class apiController extends Controller
             }
         }
         Log::info('New page of recipes pulled.', [
-            'page_retrieved' => $request->page
+            'page_retrieved' => (int)$request->page
         ]);
 
         return response()->json([
             'success'        => 'true',
-            'page_retrieved' => $request->page
+            'page_retrieved' => (int)$request->page
         ]);
     }
 

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -203,6 +203,12 @@ class apiController extends Controller
             ]);
     }
 
+    /**
+     * Gets the current page in api_raw_api_recipes along with the next page that
+     * needs to be pulled.
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function getPageInfo()
     {
         $recipe = apiRecipe::orderBy('api_recipe_page', 'desc')->first();
@@ -215,6 +221,11 @@ class apiController extends Controller
         ]);
     }
 
+    /**
+     * Gets an unpulled apiRecipe from api_raw_api_recipes and returns its ID on F2f (rId).
+     *
+     * @return \Illuminate\Http\Response
+     */
     public function getUnpulledApiRecipeId()
     {
         $recipe = apiRecipe::dataNotPulled()->first();

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -1,9 +1,7 @@
 <?php
 
 /**
- * Endpoints for handling data pulls from the Food2Fork API.
- * This is a very opinionated and verbose controller. In this case it's
- * mainly serving as couple of programatic buttons for a cron job to push.
+ * TODO: doc comment
  *
  * @author John J Lincoln <jlincoln88@gmail.com>
  * @copyright 2018 Arctic Pangolin
@@ -20,99 +18,6 @@ use Validator;
 
 class apiController extends Controller
 {
-    /**
-     * Retrieves a page of recipes from the F2F API, loads them into apiRecipe
-     * models, and saves those models.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function getNewRecipes()
-    {
-        // Grab a recipe from the last page retrieved to determine the next page to retrieve
-        $recipe_from_last_page = apiRecipe::orderBy('api_recipe_page', 'desc')->first();
-        $api_page = isset($recipe_from_last_page) ? $recipe_from_last_page->api_recipe_page + 1 : 1;
-
-        // Configure cURL
-        $params = [
-            'key'  => env('F2F_API_KEY'),
-            'page' => $api_page
-        ];
-        $defaults = [
-            CURLOPT_URL            => 'http://food2fork.com/api/search',
-            CURLOPT_POST           => true,
-            CURLOPT_POSTFIELDS     => $params,
-            CURLOPT_RETURNTRANSFER => true
-        ];
-        $ch = curl_init();
-        curl_setopt_array($ch, $defaults);
-
-        // Send request
-        $response = curl_exec($ch);
-
-        // Check for errors and display the error message
-        if ($errno = curl_errno($ch)) {
-            $error_message = curl_strerror($errno);
-            return response()->json([
-                'error' => "cURL error ({$errno}):\n {$error_message}"
-                ]);
-        }
-
-        // Close the handle and load the response
-        curl_close($ch);
-        $response = json_decode($response);
-
-        // Save new models
-        foreach ($response->recipes as $recipe) {
-            $new_api_recipe = [
-                'api_f2f_id'               => $recipe->recipe_id,
-                'api_recipe_title'         => $recipe->title,
-                'api_recipe_image_url'     => $recipe->image_url,
-                'api_recipe_source_url'    => $recipe->source_url,
-                'api_recipe_f2f_url'       => $recipe->f2f_url,
-                'api_recipe_publisher'     => $recipe->publisher,
-                'api_recipe_publisher_url' => $recipe->publisher_url,
-                'api_recipe_social_rank'   => $recipe->social_rank,
-                'api_recipe_page'          => (int)$api_page
-            ];
-            $validator = Validator::make($new_api_recipe, apiRecipe::$rules);
-            if ($validator->fails()) {
-                Log::error('Get new recipe failed. Validation failed.', [
-                    'rId'         => $recipe->recipe_id,
-                    'page_failed' => $api_page,
-                    'errors'      => $validator->errors()
-                ]);
-                return response()->json([
-                    'rId'         => $recipe->recipe_id,
-                    'success'     => 'false',
-                    'page_failed' => $api_page,
-                    'errors'      => $validator->errors()
-                ]);
-            }
-            $api_recipe_model =  new apiRecipe();
-            $api_recipe_model->fill($new_api_recipe);
-            $success = $api_recipe_model->save();
-            if (!$success) {
-                Log::error('Get new recipe failed. Save failed post validation.', [
-                    'rId'    => $recipe->api_f2f_id,
-                    'api_id' => $recipe->id,
-                    'errors' => $validator->errors()
-                ]);
-                return response()->json([
-                    'rId'     => $recipe->recipe_id,
-                    'success' => 'false',
-                    'errors'  => $validator->errors()
-                ]);
-            }
-        }
-        Log::info('New page of recipes pulled.', [
-            'page_retrieved' => $api_page
-        ]);
-        return response()->json([
-            'success'        => 'true',
-            'page_retrieved' => $api_page
-        ]);
-    }
-
     /**
      * Gets the current page in api_raw_api_recipes along with the next page that
      * needs to be pulled.
@@ -131,14 +36,9 @@ class apiController extends Controller
         ]);
     }
 
-    /**
-     * Gets an unpulled apiRecipe from api_raw_api_recipes and returns its ID on F2f (rId) as well as our api_id.
-     *
-     * @return \Illuminate\Http\Response
-     */
     public function getUnpulledApiRecipeId()
     {
-        $recipe = apiRecipe::dataNotPulled()->first();
+        $recipe = apiRecipe::dataNotPulled()->noErrors()->first();
 
         return response()->json([
             'api_f2f_id' => $recipe->api_f2f_id,
@@ -146,18 +46,8 @@ class apiController extends Controller
         ]);
     }
 
-    /**
-     * [postApiRecipe description]
-     * @param  \Illuminate\Http\Request $request
-     * @return \Illuminate\Http\Response
-     */
     public function postApiRecipes(Request $request)
     {
-        Log::info('Hit url successfully');
-        Log::info('stuff in request object', [
-            $request->all()
-        ]);
-
         foreach ($request->new_recipes as $recipe) {
             $new_api_recipe = [
                 'api_f2f_id'               => $recipe['recipe_id'],
@@ -172,7 +62,7 @@ class apiController extends Controller
             ];
             $validator = Validator::make($new_api_recipe, apiRecipe::$rules);
             if ($validator->fails()) {
-                Log::error('Get new recipe failed. Validation failed.', [
+                Log::error('Load new recipes failed. Recipe failed validation.', [
                     'rId'         => $recipe['recipe_id'],
                     'page_failed' => $request->page,
                     'errors'      => $validator->errors()
@@ -188,12 +78,12 @@ class apiController extends Controller
             $api_recipe_model->fill($new_api_recipe);
             $success = $api_recipe_model->save();
             if (!$success) {
-                Log::error('Get new recipe failed. Save failed post validation.', [
-                    'rId'    => $recipe['api_f2f_id'],
+                Log::error('Load new recipes failed. Save failed post validation.', [
+                    'rId'    => $recipe['recipe_id'],
                     'errors' => $validator->errors()
                 ]);
                 return response()->json([
-                    'rId'     => $recipe['api_f2f_id'],
+                    'rId'     => $recipe['recipe_id'],
                     'success' => 'false',
                     'errors'  => $validator->errors()
                 ]);
@@ -202,6 +92,7 @@ class apiController extends Controller
         Log::info('New page of recipes pulled.', [
             'page_retrieved' => $request->page
         ]);
+
         return response()->json([
             'success'        => 'true',
             'page_retrieved' => $request->page
@@ -215,24 +106,22 @@ class apiController extends Controller
      */
     public function postApiRecipeData(Request $request)
     {
-        Log::info('Hit url successfully');
-        Log::info('stuff in request object', [
-            $request->all()
-        ]);
         $recipe = apiRecipe::find($request->api_id);
         foreach ($request->ingredients as $ingredient) {
-            $new_api_recipe = [
+            $new_api_recipe_data = [
                 'api_id'              => $request->api_id,
                 'api_f2f_id'          => $recipe->api_f2f_id,
                 'api_ingredient_data' => isset($ingredient) ? $ingredient : 'not found'
             ];
-            $validator = Validator::make($new_api_recipe, apiRecipeData::$rules);
+            $validator = Validator::make($new_api_recipe_data, apiRecipeData::$rules);
             if ($validator->fails()) {
-                Log::error('Pull failed for rId. Validation failed.', [
+                Log::error('Load failed for rId. Validation failed.', [
                     'rId'    => $recipe->api_f2f_id,
                     'api_id' => $recipe->id,
                     'errors' => $validator->errors()
                 ]);
+                $recipe->markRecipeHasErrors();
+                $recipe->save();
                 return response()->json([
                     'rId'     => $recipe->api_f2f_id,
                     'success' => 'false',
@@ -240,10 +129,10 @@ class apiController extends Controller
                 ]);
             }
             $api_recipe_data_model = new apiRecipeData();
-            $api_recipe_data_model->fill($new_api_recipe);
+            $api_recipe_data_model->fill($new_api_recipe_data);
             $success = $api_recipe_data_model->save();
             if (!$success) {
-                Log::error('Pull failed for rId. Save failed post validation.', [
+                Log::error('Load failed for rId. Save failed post validation.', [
                     'rId'    => $recipe->api_f2f_id,
                     'api_id' => $recipe->id,
                     'errors' => $validator->errors()
@@ -256,14 +145,15 @@ class apiController extends Controller
             }
         }
         // Mark the apiRecipe as having its data pulled
-        $recipe->markRecipeDataPulled();
+        $recipe->markRecipeDataLoaded();
         $success = $recipe->save();
-        Log::info('Recipe pulled.', [
+        Log::info('Recipe loaded.', [
             'rId' => $recipe->api_f2f_id
         ]);
+
         return response()->json([
             'success' => $success,
-            'string'  => $success ? 'Recipe ' . $recipe->api_f2f_id . ' pulled!' : 'Pull failed on recipe ' . $recipe->api_f2f_id
+            'string'  => $success ? 'Recipe ' . $recipe->api_f2f_id . ' loaded!' : 'Load failed on recipe ' . $recipe->api_f2f_id
             ]);
     }
 }

--- a/app/Http/Controllers/API/apiController.php
+++ b/app/Http/Controllers/API/apiController.php
@@ -114,96 +114,6 @@ class apiController extends Controller
     }
 
     /**
-     * Retrieves data for an apiRecipe from the F2F API, loads the data into apiRecipeData
-     * models, and saves those models. This function loads apiRecipeData models for the
-     * first apiRecipe that has not had its data pulled.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function getRecipeData()
-    {
-        // Grab any apiRecipe that has not had its data pulled
-        $recipe = apiRecipe::dataNotPulled()->first();
-
-        // Configure cURL
-        $params = [
-            'key' => env('F2F_API_KEY'),
-            'rId' => $recipe->api_f2f_id
-        ];
-        $defaults = [
-            CURLOPT_URL            => 'http://food2fork.com/api/get',
-            CURLOPT_POST           => true,
-            CURLOPT_POSTFIELDS     => $params,
-            CURLOPT_RETURNTRANSFER => true
-        ];
-        $ch = curl_init();
-        curl_setopt_array($ch, $defaults);
-
-        // Send request
-        $response = curl_exec($ch);
-
-        // Check for errors and display the error message
-        if ($errno = curl_errno($ch)) {
-            $error_message = curl_strerror($errno);
-            return response()->json([
-                'error' => "cURL error ({$errno}):\n {$error_message}"
-                ]);
-        }
-
-        // Close the handle and load the response
-        curl_close($ch);
-        $response = json_decode($response);
-
-        // Save new models
-        foreach ($response->recipe->ingredients as $ingredient) {
-            $new_api_recipe_data = [
-                'api_id'              => $recipe->id,
-                'api_f2f_id'          => $recipe->api_f2f_id,
-                'api_ingredient_data' => isset($ingredient) ? $ingredient : 'not found'
-            ];
-            $validator = Validator::make($new_api_recipe_data, apiRecipeData::$rules);
-            if ($validator->fails()) {
-                Log::error('Pull failed for rId. Validation failed.', [
-                    'rId'    => $recipe->api_f2f_id,
-                    'api_id' => $recipe->id,
-                    'errors' => $validator->errors()
-                ]);
-                return response()->json([
-                    'rId'     => $recipe->api_f2f_id,
-                    'success' => 'false',
-                    'errors'  => $validator->errors()
-                ]);
-            }
-            $api_recipe_data_model = new apiRecipeData();
-            $api_recipe_data_model->fill($new_api_recipe_data);
-            $success = $api_recipe_data_model->save();
-            if (!$success) {
-                Log::error('Pull failed for rId. Save failed post validation.', [
-                    'rId'    => $recipe->api_f2f_id,
-                    'api_id' => $recipe->id,
-                    'errors' => $validator->errors()
-                ]);
-                return response()->json([
-                    'rId'     => $recipe->api_f2f_id,
-                    'success' => 'false',
-                    'errors'  => $validator->errors()
-                ]);
-            }
-        }
-
-        // Mark the apiRecipe as having its data pulled
-        $recipe->markRecipeDataPulled();
-        $success = $recipe->save();
-        Log::info('Recipe pulled.', [
-            'rId' => $recipe->api_f2f_id
-        ]);
-        return response()->json([
-            'success' => $success,
-            'string'  => $success ? 'Recipe ' . $recipe->api_f2f_id . ' pulled!' : 'Pull failed on recipe ' . $recipe->api_f2f_id
-            ]);
-    }
-
-    /**
      * Gets the current page in api_raw_api_recipes along with the next page that
      * needs to be pulled.
      *
@@ -222,7 +132,7 @@ class apiController extends Controller
     }
 
     /**
-     * Gets an unpulled apiRecipe from api_raw_api_recipes and returns its ID on F2f (rId).
+     * Gets an unpulled apiRecipe from api_raw_api_recipes and returns its ID on F2f (rId) as well as our api_id.
      *
      * @return \Illuminate\Http\Response
      */
@@ -231,7 +141,129 @@ class apiController extends Controller
         $recipe = apiRecipe::dataNotPulled()->first();
 
         return response()->json([
-            'api_f2f_id' => $recipe->api_f2f_id
+            'api_f2f_id' => $recipe->api_f2f_id,
+            'api_id'     => $recipe->id
         ]);
+    }
+
+    /**
+     * [postApiRecipe description]
+     * @param  \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function postApiRecipes(Request $request)
+    {
+        Log::info('Hit url successfully');
+        Log::info('stuff in request object', [
+            $request->all()
+        ]);
+
+        foreach ($request->new_recipes as $recipe) {
+            $new_api_recipe = [
+                'api_f2f_id'               => $recipe['recipe_id'],
+                'api_recipe_title'         => $recipe['title'],
+                'api_recipe_image_url'     => $recipe['image_url'],
+                'api_recipe_source_url'    => $recipe['source_url'],
+                'api_recipe_f2f_url'       => $recipe['f2f_url'],
+                'api_recipe_publisher'     => $recipe['publisher'],
+                'api_recipe_publisher_url' => $recipe['publisher_url'],
+                'api_recipe_social_rank'   => $recipe['social_rank'],
+                'api_recipe_page'          => $request->page
+            ];
+            $validator = Validator::make($new_api_recipe, apiRecipe::$rules);
+            if ($validator->fails()) {
+                Log::error('Get new recipe failed. Validation failed.', [
+                    'rId'         => $recipe['recipe_id'],
+                    'page_failed' => $request->page,
+                    'errors'      => $validator->errors()
+                ]);
+                return response()->json([
+                    'rId'         => $recipe['recipe_id'],
+                    'success'     => 'false',
+                    'page_failed' => $request->page,
+                    'errors'      => $validator->errors()
+                ]);
+            }
+            $api_recipe_model =  new apiRecipe();
+            $api_recipe_model->fill($new_api_recipe);
+            $success = $api_recipe_model->save();
+            if (!$success) {
+                Log::error('Get new recipe failed. Save failed post validation.', [
+                    'rId'    => $recipe['api_f2f_id'],
+                    'errors' => $validator->errors()
+                ]);
+                return response()->json([
+                    'rId'     => $recipe['api_f2f_id'],
+                    'success' => 'false',
+                    'errors'  => $validator->errors()
+                ]);
+            }
+        }
+        Log::info('New page of recipes pulled.', [
+            'page_retrieved' => $request->page
+        ]);
+        return response()->json([
+            'success'        => 'true',
+            'page_retrieved' => $request->page
+        ]);
+    }
+
+    /**
+     * [postApiRecipeData description]
+     * @param  \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function postApiRecipeData(Request $request)
+    {
+        Log::info('Hit url successfully');
+        Log::info('stuff in request object', [
+            $request->all()
+        ]);
+        $recipe = apiRecipe::find($request->api_id);
+        foreach ($request->ingredients as $ingredient) {
+            $new_api_recipe = [
+                'api_id'              => $request->api_id,
+                'api_f2f_id'          => $recipe->api_f2f_id,
+                'api_ingredient_data' => isset($ingredient) ? $ingredient : 'not found'
+            ];
+            $validator = Validator::make($new_api_recipe, apiRecipeData::$rules);
+            if ($validator->fails()) {
+                Log::error('Pull failed for rId. Validation failed.', [
+                    'rId'    => $recipe->api_f2f_id,
+                    'api_id' => $recipe->id,
+                    'errors' => $validator->errors()
+                ]);
+                return response()->json([
+                    'rId'     => $recipe->api_f2f_id,
+                    'success' => 'false',
+                    'errors'  => $validator->errors()
+                ]);
+            }
+            $api_recipe_data_model = new apiRecipeData();
+            $api_recipe_data_model->fill($new_api_recipe);
+            $success = $api_recipe_data_model->save();
+            if (!$success) {
+                Log::error('Pull failed for rId. Save failed post validation.', [
+                    'rId'    => $recipe->api_f2f_id,
+                    'api_id' => $recipe->id,
+                    'errors' => $validator->errors()
+                ]);
+                return response()->json([
+                    'rId'     => $recipe->api_f2f_id,
+                    'success' => 'false',
+                    'errors'  => $validator->errors()
+                ]);
+            }
+        }
+        // Mark the apiRecipe as having its data pulled
+        $recipe->markRecipeDataPulled();
+        $success = $recipe->save();
+        Log::info('Recipe pulled.', [
+            'rId' => $recipe->api_f2f_id
+        ]);
+        return response()->json([
+            'success' => $success,
+            'string'  => $success ? 'Recipe ' . $recipe->api_f2f_id . ' pulled!' : 'Pull failed on recipe ' . $recipe->api_f2f_id
+            ]);
     }
 }

--- a/app/Jobs/apiGetNewRecipeData.php
+++ b/app/Jobs/apiGetNewRecipeData.php
@@ -1,19 +1,27 @@
 <?php
 /**
-* TODO: doc comment
-* TODO: Comment Inline
+* PHP Script to handle getting data for recipes from the Food2Fork API and sending it to fridgebuffet.
 *
 * @author John J Lincoln <jlincoln88@gmail.com>
 * @copyright 2018 Arctic Pangolin
 */
 
-//have to load env somehow
+/**
+ * Script Arguments
+ * These MUST be passed in when executing this script to ensure functionality
+ *
+ * Argument 1 - Base URL of the application
+ * Argument 2 - F2F API Key
+ *
+ * @example php /path/to/apiGetNewRecipeData.php http://www.fridgebuffet.com 1337s3Kr3tAp1k3y1337
+ * @var array
+ */
 $script_arguments = [
     'base_url'    => !empty($argv[1]) ? $argv[1] : 'localhost',
     'f2f_api_key' => !empty($argv[2]) ? $argv[2] : '',
 ];
 
-// Configure cURL for an internal API call
+// Configure cURL to request an unpulled apiRecie from the fridgebuffet apiRecipes
 $defaults = [
     CURLOPT_URL            => $script_arguments['base_url'] . '/api/get/unpulledApiRecipe',
     CURLOPT_RETURNTRANSFER => true
@@ -25,20 +33,21 @@ curl_setopt_array($ch, $defaults);
 $response = curl_exec($ch);
 $response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     echo "cURL error ({$errno}):\n {$error_message}";
+    die();
 }
 
 // Close the handle
 curl_close($ch);
 
-// lod if succes
+// Save the apiRecipe ID and corresponding Food2Fork ID
 $unpulled_api_f2f_id = $response->api_f2f_id;
 $unpulled_api_id = $response->api_id;
 
-// Configure cURL for API call to Food2Fork.
+// Configure cURL for API call to Food2Fork
 $params = [
     'key' => $script_arguments['f2f_api_key'],
     'rId' => $unpulled_api_f2f_id
@@ -50,17 +59,19 @@ $defaults = [
     CURLOPT_POSTFIELDS     => $params,
     CURLOPT_RETURNTRANSFER => true
 ];
+
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
+// Send request and load response
 $response = curl_exec($ch);
 $response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     echo "cURL error ({$errno}):\n {$error_message}";
+    die();
 }
 
 if (!isset($response)) {
@@ -71,10 +82,10 @@ if (!isset($response)) {
 // Close the handle
 curl_close($ch);
 
-//lod if succ
+// Save the new recipe data
 $ingredients = $response->recipe->ingredients;
 
-// Configure cURL
+// Configure cURL to send a payload of recipe data to the fridgebuffet API
 $new_api_recipe_data = [
     'api_f2f_id'  => $unpulled_api_f2f_id,
     'api_id'      => $unpulled_api_id,
@@ -86,7 +97,7 @@ $http_header = [
     'Content-Type: application/json',
     'Content-Length: ' . strlen($payload)
 ];
-// curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+
 $defaults = [
     CURLOPT_URL            => $script_arguments['base_url'] . '/api/post/apiRecipeData',
     CURLOPT_POST           => true,
@@ -94,22 +105,25 @@ $defaults = [
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_HTTPHEADER     => $http_header
 ];
+
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
+// Send request and load response
 $response = curl_exec($ch);
-$response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     return response()->json([
         'error' => "cURL error ({$errno}):\n {$error_message}"
         ]);
+    die();
 }
 
-echo isset($response) ? var_dump($response) : 'Error - Check data';
+// Echo the json response of the fridgebuffet endpoint
+echo $response;
 
-// Close the handle and load the response
+// Close the handle and die
 curl_close($ch);
+die();

--- a/app/Jobs/apiGetNewRecipeData.php
+++ b/app/Jobs/apiGetNewRecipeData.php
@@ -1,6 +1,7 @@
 <?php
 /**
-* PHP Script to handle getting recipe specific data from the Food2Fork API.
+* TODO: doc comment
+* TODO: Comment Inline
 *
 * @author John J Lincoln <jlincoln88@gmail.com>
 * @copyright 2018 Arctic Pangolin
@@ -108,7 +109,7 @@ if ($errno = curl_errno($ch)) {
         ]);
 }
 
-echo isset($response) ? var_dump($response) : 'Completed successfully';
+echo isset($response) ? var_dump($response) : 'Error - Check data';
 
 // Close the handle and load the response
 curl_close($ch);

--- a/app/Jobs/apiGetNewRecipeData.php
+++ b/app/Jobs/apiGetNewRecipeData.php
@@ -6,19 +6,23 @@
 * @copyright 2018 Arctic Pangolin
 */
 
-$params = [
-    'url' => !empty($argv[1]) ? $argv[1] : 'localhost/api/get/recipeData'
+//have to load env somehow
+$script_arguments = [
+    'base_url'    => !empty($argv[1]) ? $argv[1] : 'localhost',
+    'f2f_api_key' => !empty($argv[2]) ? $argv[2] : '',
 ];
 
-// Configure cURL
+// Configure cURL for an internal API call
 $defaults = [
-    CURLOPT_URL => $params['url']
+    CURLOPT_URL            => $script_arguments['base_url'] . '/api/get/unpulledApiRecipe',
+    CURLOPT_RETURNTRANSFER => true
 ];
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
-curl_exec($ch);
+// Send request and load response
+$response = curl_exec($ch);
+$response = json_decode($response);
 
 // Check for errors and display the error message
 if ($errno = curl_errno($ch)) {
@@ -26,6 +30,85 @@ if ($errno = curl_errno($ch)) {
     echo "cURL error ({$errno}):\n {$error_message}";
 }
 
-// Close the handle and die.
+// Close the handle
 curl_close($ch);
-die();
+
+// lod if succes
+$unpulled_api_f2f_id = $response->api_f2f_id;
+$unpulled_api_id = $response->api_id;
+
+// Configure cURL for API call to Food2Fork.
+$params = [
+    'key' => $script_arguments['f2f_api_key'],
+    'rId' => $unpulled_api_f2f_id
+];
+
+$defaults = [
+    CURLOPT_URL            => 'http://food2fork.com/api/get',
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $params,
+    CURLOPT_RETURNTRANSFER => true
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+$response = curl_exec($ch);
+$response = json_decode($response);
+
+// Check for errors and display the error message
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    echo "cURL error ({$errno}):\n {$error_message}";
+}
+
+if (!isset($response)) {
+    echo 'Failed to retrieve recipe data...';
+    die();
+}
+
+// Close the handle
+curl_close($ch);
+
+//lod if succ
+$ingredients = $response->recipe->ingredients;
+
+// Configure cURL
+$new_api_recipe_data = [
+    'api_f2f_id'  => $unpulled_api_f2f_id,
+    'api_id'      => $unpulled_api_id,
+    'ingredients' => $ingredients
+];
+
+$payload = json_encode($new_api_recipe_data);
+$http_header = [
+    'Content-Type: application/json',
+    'Content-Length: ' . strlen($payload)
+];
+// curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+$defaults = [
+    CURLOPT_URL            => $script_arguments['base_url'] . '/api/post/apiRecipeData',
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $payload,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => $http_header
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+$response = curl_exec($ch);
+$response = json_decode($response);
+
+// Check for errors and display the error message
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    return response()->json([
+        'error' => "cURL error ({$errno}):\n {$error_message}"
+        ]);
+}
+
+echo isset($response) ? var_dump($response) : 'Completed successfully';
+
+// Close the handle and load the response
+curl_close($ch);

--- a/app/Jobs/apiGetNewRecipes.php
+++ b/app/Jobs/apiGetNewRecipes.php
@@ -1,6 +1,7 @@
 <?php
 /**
 * PHP Script to handle getting new recipes from the Food2Fork API.
+* TODO: comment inline
 *
 * @author John J Lincoln <jlincoln88@gmail.com>
 * @copyright 2018 Arctic Pangolin

--- a/app/Jobs/apiGetNewRecipes.php
+++ b/app/Jobs/apiGetNewRecipes.php
@@ -1,23 +1,32 @@
 <?php
 /**
-* PHP Script to handle getting new recipes from the Food2Fork API.
-* TODO: comment inline
+* PHP Script to handle getting new recipes from the Food2Fork API and sending them to fridgebuffet.
 *
 * @author John J Lincoln <jlincoln88@gmail.com>
 * @copyright 2018 Arctic Pangolin
 */
 
-//have to load env somehow
+/**
+ * Script Arguments
+ * These MUST be passed in when executing this script to ensure functionality
+ *
+ * Argument 1 - Base URL of the application
+ * Argument 2 - F2F API Key
+ *
+ * @example php /path/to/apiGetNewRecipes.php http://www.fridgebuffet.com 1234s3Kr3tAp1k3y1234
+ * @var array
+ */
 $script_arguments = [
     'base_url'    => !empty($argv[1]) ? $argv[1] : 'localhost',
     'f2f_api_key' => !empty($argv[2]) ? $argv[2] : '',
 ];
 
-// Configure cURL for an internal API call
+// Configure cURL to request page info from the fridgebuffet API
 $defaults = [
     CURLOPT_URL            => $script_arguments['base_url'] . '/api/get/pageInfo',
     CURLOPT_RETURNTRANSFER => true
 ];
+
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
@@ -25,19 +34,20 @@ curl_setopt_array($ch, $defaults);
 $response = curl_exec($ch);
 $response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     echo "cURL error ({$errno}):\n {$error_message}";
+    die();
 }
 
 // Close the handle
 curl_close($ch);
 
-// lod if succes
+// Save the page number of the next page of recipes to request from Food2Fork
 $page = $response->next_page ?? $response->current_page;
 
-// Configure cURL for API call to Food2Fork.
+// Configure cURL for API call to Food2Fork
 $params = [
     'key'  => $script_arguments['f2f_api_key'],
     'page' => $page
@@ -49,17 +59,19 @@ $defaults = [
     CURLOPT_POSTFIELDS     => $params,
     CURLOPT_RETURNTRANSFER => true
 ];
+
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
+// Send request and load response
 $response = curl_exec($ch);
 $response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     echo "cURL error ({$errno}):\n {$error_message}";
+    die();
 }
 
 if (!isset($response)) {
@@ -70,11 +82,11 @@ if (!isset($response)) {
 // Close the handle
 curl_close($ch);
 
-//lod if succ
+// Save the new recipes as well as the count of new recipes
 $new_recipes = $response->recipes;
 $new_recipes_count = $response->count;
 
-// Configure cURL
+// Configure cURL to send a payload of new recipes to the fridgebuffet API
 $new_api_recipes = [
     'page'              => $page,
     'new_recipes'       => $new_recipes,
@@ -94,23 +106,25 @@ $defaults = [
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_HTTPHEADER     => $http_header
 ];
+
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
+// Send request and load response
 $response = curl_exec($ch);
-$response = json_decode($response);
 
-// Check for errors and display the error message
+// Check for errors and display the error message - die if error
 if ($errno = curl_errno($ch)) {
     $error_message = curl_strerror($errno);
     return response()->json([
         'error' => "cURL error ({$errno}):\n {$error_message}"
         ]);
+    die();
 }
 
-var_dump($response);
+// Echo the json response of the fridgebuffet endpoint
+echo $response;
 
-// Close the handle and load the response
+// Close the handle and die
 curl_close($ch);
 die();

--- a/app/Jobs/apiGetNewRecipes.php
+++ b/app/Jobs/apiGetNewRecipes.php
@@ -6,19 +6,23 @@
 * @copyright 2018 Arctic Pangolin
 */
 
-$params = [
-    'url' => !empty($argv[1]) ? $argv[1] : 'localhost/api/get/newRecipes'
+//have to load env somehow
+$script_arguments = [
+    'base_url'    => !empty($argv[1]) ? $argv[1] : 'localhost',
+    'f2f_api_key' => !empty($argv[2]) ? $argv[2] : '',
 ];
 
-// Configure cURL
+// Configure cURL for an internal API call
 $defaults = [
-    CURLOPT_URL => $params['url']
+    CURLOPT_URL            => $script_arguments['base_url'] . '/api/get/pageInfo',
+    CURLOPT_RETURNTRANSFER => true
 ];
 $ch = curl_init();
 curl_setopt_array($ch, $defaults);
 
-// Send request
-curl_exec($ch);
+// Send request and load response
+$response = curl_exec($ch);
+$response = json_decode($response);
 
 // Check for errors and display the error message
 if ($errno = curl_errno($ch)) {
@@ -26,6 +30,86 @@ if ($errno = curl_errno($ch)) {
     echo "cURL error ({$errno}):\n {$error_message}";
 }
 
-// Close the handle and die.
+// Close the handle
+curl_close($ch);
+
+// lod if succes
+$page = $response->next_page ?? $response->current_page;
+
+// Configure cURL for API call to Food2Fork.
+$params = [
+    'key'  => $script_arguments['f2f_api_key'],
+    'page' => $page
+];
+
+$defaults = [
+    CURLOPT_URL            => 'http://food2fork.com/api/search',
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $params,
+    CURLOPT_RETURNTRANSFER => true
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+$response = curl_exec($ch);
+$response = json_decode($response);
+
+// Check for errors and display the error message
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    echo "cURL error ({$errno}):\n {$error_message}";
+}
+
+if (!isset($response)) {
+    echo 'Failed to retrieve new recipes...';
+    die();
+}
+
+// Close the handle
+curl_close($ch);
+
+//lod if succ
+$new_recipes = $response->recipes;
+$new_recipes_count = $response->count;
+
+// Configure cURL
+$new_api_recipes = [
+    'page'              => $page,
+    'new_recipes'       => $new_recipes,
+    'new_recipes_count' => $new_recipes_count
+];
+
+$payload = json_encode($new_api_recipes);
+$http_header = [
+    'Content-Type: application/json',
+    'Content-Length: ' . strlen($payload)
+];
+
+$defaults = [
+    CURLOPT_URL            => $script_arguments['base_url'] . '/api/post/apiRecipes',
+    CURLOPT_POST           => true,
+    CURLOPT_POSTFIELDS     => $payload,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER     => $http_header
+];
+$ch = curl_init();
+curl_setopt_array($ch, $defaults);
+
+// Send request
+$response = curl_exec($ch);
+$response = json_decode($response);
+
+// Check for errors and display the error message
+if ($errno = curl_errno($ch)) {
+    $error_message = curl_strerror($errno);
+    return response()->json([
+        'error' => "cURL error ({$errno}):\n {$error_message}"
+        ]);
+}
+
+var_dump($response);
+
+// Close the handle and load the response
 curl_close($ch);
 die();

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -84,9 +84,6 @@ class apiRecipe extends Model
         'api_recipe_page'          => 'numeric'
     ];
 
-    /**
-    * Get the apiRecipeData that belongs to this apiRecipe.
-    */
     public function apiRecipeData()
     {
         return $this->hasMany('App\Models\API\apiRecipeData');
@@ -100,17 +97,27 @@ class apiRecipe extends Model
     */
     public function scopeDataNotPulled($query)
     {
-        return $query->where('api_recipe_data_pulled', false);
+        return $query->where('api_recipe_data_loaded', false);
+    }
+
+    public function scopeNoErrors($query)
+    {
+        return $query->where('api_recipe_has_errors', false);
     }
 
     /**
-     * Marks the current apiRecipe as "pulled" indicating that its apiRecipeData model(s)
-     * have been pulled from the F2F API.
+     * Marks the current apiRecipe as "loaded" indicating that its apiRecipeData model(s)
+     * have been pulled from the F2F API and successfully loaded.
      *
      * @return bool
      */
-    public function markRecipeDataPulled()
+    public function markRecipeDataLoaded()
     {
-        return $this->api_recipe_data_pulled = true;
+        return $this->api_recipe_data_loaded = true;
+    }
+
+    public function markRecipeHasErrors()
+    {
+        return $this->api_recipe_has_errors = true;
     }
 }

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -2,7 +2,6 @@
 
 /**
  * Model for Recipes pulled from the Food2Fork API
- * TODO: COMMENT NEW FUNCTIONS
  *
  * @author John J Lincoln <jlincoln88@gmail.com>
  * @copyright 2018 Arctic Pangolin
@@ -85,22 +84,31 @@ class apiRecipe extends Model
         'api_recipe_page'          => 'numeric'
     ];
 
+    /**
+     * The apiRecipeData models that belong to this apiRecipe.
+     */
     public function apiRecipeData()
     {
-        return $this->hasMany('App\Models\API\apiRecipeData');
+        return $this->hasMany('App\Models\API\apiRecipeData', 'api_id');
     }
 
     /**
-    * Scopes a query to only include recipes that have not had their data pulled.
+    * Scopes a query to only include apiRecipes that have not had their data pulled.
     *
     * @param \Illuminate\Database\Eloquent\Builder $query
     * @return \Illuminate\Database\Eloquent\Builder
     */
-    public function scopeDataNotPulled($query)
+    public function scopeDataNotLoaded($query)
     {
         return $query->where('api_recipe_data_loaded', false);
     }
 
+    /**
+     * Scopes a query to only include apiRecipes that have errors.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function scopeNoErrors($query)
     {
         return $query->where('api_recipe_has_errors', false);
@@ -117,6 +125,11 @@ class apiRecipe extends Model
         return $this->api_recipe_data_loaded = true;
     }
 
+    /**
+     * Marks the current apiRecipe as riddled with errors. Womp womp.
+     *
+     * @return bool
+     */
     public function markRecipeHasErrors()
     {
         return $this->api_recipe_has_errors = true;

--- a/app/Models/API/apiRecipe.php
+++ b/app/Models/API/apiRecipe.php
@@ -2,6 +2,7 @@
 
 /**
  * Model for Recipes pulled from the Food2Fork API
+ * TODO: COMMENT NEW FUNCTIONS
  *
  * @author John J Lincoln <jlincoln88@gmail.com>
  * @copyright 2018 Arctic Pangolin

--- a/app/Models/API/apiRecipeData.php
+++ b/app/Models/API/apiRecipeData.php
@@ -73,6 +73,6 @@ class apiRecipeData extends Model
     */
     public function apiRecipe()
     {
-        return $this->belongsTo('App\Models\API\apiRecipe');
+        return $this->belongsTo('App\Models\API\apiRecipe', 'api_id');
     }
 }

--- a/database/migrations/2018_04_06_020325_create_raw_api_recipes_table.php
+++ b/database/migrations/2018_04_06_020325_create_raw_api_recipes_table.php
@@ -24,7 +24,9 @@ class CreateRawApiRecipesTable extends Migration
             $table->string('api_recipe_publisher_url');
             $table->decimal('api_recipe_social_rank');
             $table->unsignedInteger('api_recipe_page');
-            $table->boolean('api_recipe_data_pulled')
+            $table->boolean('api_recipe_data_loaded')
+                  ->default(false);
+            $table->boolean('api_recipe_has_errors')
                   ->default(false);
             $table->integer('assigned_recipe_id')
                   ->nullable();

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,8 +19,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 // TODO: implement auth
 // Route::middleware('auth:api')->get('/get/newRecipes', 'API\apiController@getNewRecipes');
-Route::get('/get/newRecipes', 'API\apiController@getNewRecipes');
-Route::get('/get/recipeData', 'API\apiController@getRecipeData');
+
 Route::get('/get/pageInfo', 'API\apiController@getPageInfo');
 Route::get('/get/unpulledApiRecipe', 'API\apiController@getUnpulledApiRecipeId');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 // Route::middleware('auth:api')->get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/recipeData', 'API\apiController@getRecipeData');
+Route::get('/get/pageInfo', 'API\apiController@getPageInfo');
+Route::get('/get/unpulledApiRecipe', 'API\apiController@getUnpulledApiRecipeId');

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,3 +23,6 @@ Route::get('/get/newRecipes', 'API\apiController@getNewRecipes');
 Route::get('/get/recipeData', 'API\apiController@getRecipeData');
 Route::get('/get/pageInfo', 'API\apiController@getPageInfo');
 Route::get('/get/unpulledApiRecipe', 'API\apiController@getUnpulledApiRecipeId');
+
+Route::post('/post/apiRecipeData', 'API\apiController@postApiRecipeData');
+Route::post('/post/apiRecipes', 'API\apiController@postApiRecipes');


### PR DESCRIPTION
This PR contains a bunch of small improvements, but constitutes MVP for the Food2Fork integration.

Separated concerns a bit better - the apiController class is now much less opinionated, and can be used to add new apiRecipe or apiRecipeData models from any source. cURL commands have been moved into the jobs (where they belong) and now handle grabbing data from F2F, then sending the payload to fridgebuffet.

Also some comment and naming tweaks.