### PR TITLE
Patch Database Migrations

### DIFF
--- a/database/migrations/2018_04_06_015533_create_recipes_table.php
+++ b/database/migrations/2018_04_06_015533_create_recipes_table.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateRecipesTable extends Migration
+class CreateRecipesTable_OLD extends Migration
 {
     /**
     * Run the migrations.

--- a/database/migrations/2018_04_06_020033_create_ingredients_table.php
+++ b/database/migrations/2018_04_06_020033_create_ingredients_table.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateIngredientsTable extends Migration
+class CreateIngredientsTable_OLD extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2018_04_06_020045_create_instructions_table.php
+++ b/database/migrations/2018_04_06_020045_create_instructions_table.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateInstructionsTable extends Migration
+class CreateInstructionsTable_OLD extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2018_04_26_044932_drop_placeholder_tables.php
+++ b/database/migrations/2018_04_26_044932_drop_placeholder_tables.php
@@ -13,9 +13,9 @@ class DropPlaceholderTables extends Migration
      */
     public function up()
     {
-        Schema::dropIfExists('recipes');
-        Schema::dropIfExists('ingredients');
         Schema::dropIfExists('instructions');
+        Schema::dropIfExists('ingredients');
+        Schema::dropIfExists('recipes');
     }
 
     /**
@@ -25,8 +25,8 @@ class DropPlaceholderTables extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('recipes');
-        Schema::dropIfExists('ingredients');
         Schema::dropIfExists('instructions');
+        Schema::dropIfExists('ingredients');
+        Schema::dropIfExists('recipes');
     }
 }

--- a/database/migrations/2018_05_01_013935_create_recipes_table.php
+++ b/database/migrations/2018_05_01_013935_create_recipes_table.php
@@ -22,7 +22,7 @@ class CreateRecipesTable extends Migration
             $table->timestamps();
         });
         // set PK (id) to start at 100000
-        DB::update("ALTER TABLE recipes AUTO_INCREMENT = 100000;");
+        DB::statement("ALTER TABLE recipes AUTO_INCREMENT = 100000;");
     }
 
     /**

--- a/database/migrations/2018_05_01_013953_create_ingredients_table.php
+++ b/database/migrations/2018_05_01_013953_create_ingredients_table.php
@@ -26,7 +26,7 @@ class CreateIngredientsTable extends Migration
                   ->onDelete('cascade');
         });
         // set PK (id) to start at 100000
-        DB::update("ALTER TABLE ingredients AUTO_INCREMENT = 100000;");
+        DB::statement("ALTER TABLE ingredients AUTO_INCREMENT = 100000;");
     }
 
     /**

--- a/database/migrations/2018_05_01_014007_create_instructions_table.php
+++ b/database/migrations/2018_05_01_014007_create_instructions_table.php
@@ -25,7 +25,7 @@ class CreateInstructionsTable extends Migration
                   ->onDelete('cascade');
         });
         // set PK (id) to start at 100000
-        DB::update("ALTER TABLE instructions AUTO_INCREMENT = 100000;");
+        DB::statement("ALTER TABLE instructions AUTO_INCREMENT = 100000;");
     }
 
     /**


### PR DESCRIPTION
This PR contains critical DB migration patches. These patches include:

- Rename old create_table migrations so class names are not repeated (causes conflicts)
- Reorder the drop_table migration so that child tables are dropped first (causes conflicts)
- Change query builder static call from "update" to "statement" when altering the AUTO INCREMENT property (update soft fails - no error but no effect)

NOTE: Once this is deployed, we'll need to rollback the previous migrations, and then run them again. Rollback will only rollback migration batch 2, so the api tables will be unaffected.